### PR TITLE
[MODELS] Freeze dataclasses

### DIFF
--- a/bot/models/keyboard.py
+++ b/bot/models/keyboard.py
@@ -6,7 +6,7 @@ from pynput.keyboard import Controller, Key, KeyCode
 from bot.models.timer import Timer
 
 
-@dataclass
+@dataclass(frozen=True)
 class BaseKey:
     key: str
     vk: int | None = None
@@ -22,7 +22,7 @@ class ModifierKey(BaseKey):
         return key_repr.capitalize()
 
 
-@dataclass
+@dataclass(frozen=True)
 class Keystroke(BaseKey):
     modifier: ModifierKey | None = None
     controller: ClassVar[Controller] = Controller()
@@ -49,7 +49,7 @@ class Keystroke(BaseKey):
                 self.controller.release(self.modifier.key_code)
 
 
-@dataclass
+@dataclass(frozen=True)
 class DirectionalKeystroke(Keystroke):
     def __repr__(self) -> str:
         return f"{self.key.capitalize()} {self.hold!r}"

--- a/bot/models/mouse.py
+++ b/bot/models/mouse.py
@@ -11,7 +11,7 @@ class Button(IntEnum):
     right = auto()
 
 
-@dataclass
+@dataclass(frozen=True)
 class MouseClick:
     kind: Button
     pos: tuple[int, int]

--- a/bot/models/params.py
+++ b/bot/models/params.py
@@ -5,7 +5,7 @@ from bot.models.command import Command
 
 @dataclass(frozen=True)
 class Params:
-    commands: list[Command] = field(default_factory=list)
+    commands: tuple[Command, ...] = field(default_factory=tuple)
     winNum: int = 1
     limit: int = 5
     interval: str = "1"

--- a/bot/models/params.py
+++ b/bot/models/params.py
@@ -3,7 +3,7 @@ from dataclasses import dataclass, field
 from bot.models.command import Command
 
 
-@dataclass
+@dataclass(frozen=True)
 class Params:
     commands: list[Command] = field(default_factory=list)
     winNum: int = 1

--- a/bot/models/timer.py
+++ b/bot/models/timer.py
@@ -2,7 +2,7 @@ import time
 from dataclasses import dataclass
 
 
-@dataclass
+@dataclass(frozen=True)
 class Timer:
     milliseconds: int = 200
 

--- a/bot/ui/mixins/config.py
+++ b/bot/ui/mixins/config.py
@@ -37,7 +37,7 @@ class ConfigMixin(QMainWindow):
         logger.info(f"Loading config from {filepath}")
         try:
             if result := loadConfig(filepath):
-                self.commandModel.commands = result.commands
+                self.commandModel.commands = list(result.commands)
                 self.ui.interval.setText(result.interval)
                 self.ui.limit.setText(str(result.limit))
                 self.ui.winNum.setCurrentText(str(result.winNum))
@@ -97,7 +97,7 @@ class ConfigMixin(QMainWindow):
 
     def dumpConfig(self) -> Params:
         return Params(
-            commands=self.commandModel.commands,
+            commands=tuple(self.commandModel.commands),
             interval=self.ui.interval.text(),
             limit=int(self.ui.limit.text()),
             winNum=int(self.ui.winNum.currentText()),

--- a/bot/utils/config.py
+++ b/bot/utils/config.py
@@ -72,7 +72,7 @@ def loadConfig(filename: str) -> Params | None:
         winNum=win_num,
         limit=limit,
         interval=interval,
-        commands=[c for line in lines[3:] if (c := parse_commands(line))],
+        commands=tuple(c for line in lines[3:] if (c := parse_commands(line))),
     )
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,6 +13,7 @@ from bot.models import (
     MouseClick,
     Params,
 )
+from bot.models.command import Command
 
 CURRENT_FOLDER = Path(__file__).parent
 RES_FOLDER = CURRENT_FOLDER / "res"
@@ -73,23 +74,15 @@ def directional_key_factory():
 @pytest.fixture
 def params_factory(stroke_factory, click_factory, directional_key_factory):
     def _create(
-        limit: float = 0.01,
+        limit: int = 1,
         winNum: int = 1,
         interval: str = "1-2",
-        num_keystrokes: int = 1,
-        num_mouse_click: int = 1,
+        commands: list[Command] | None = None,
     ):
-        commands = []
-        for _ in range(1, num_keystrokes + 1):
-            commands.append(stroke_factory())
-        for _ in range(1, num_mouse_click + 1):
-            commands.append(click_factory())
-
-        commands.append(directional_key_factory())
-
         return Params(
-            limit=limit,  # type: ignore
-            commands=commands,
+            limit=limit,
+            commands=commands
+            or [stroke_factory(), click_factory(), directional_key_factory()],
             winNum=winNum,
             interval=interval,
         )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -77,12 +77,12 @@ def params_factory(stroke_factory, click_factory, directional_key_factory):
         limit: int = 1,
         winNum: int = 1,
         interval: str = "1-2",
-        commands: list[Command] | None = None,
+        commands: tuple[Command, ...] | None = None,
     ):
         return Params(
             limit=limit,
             commands=commands
-            or [stroke_factory(), click_factory(), directional_key_factory()],
+            or tuple([stroke_factory(), click_factory(), directional_key_factory()]),
             winNum=winNum,
             interval=interval,
         )

--- a/tests/core/test_control.py
+++ b/tests/core/test_control.py
@@ -8,7 +8,7 @@ from bot.models.command import Command
 
 def test_run(params_factory):
     cmd_mock = Mock(spec=Command)
-    p = params_factory(winNum=2, commands=[cmd_mock], interval="1")
+    p = params_factory(winNum=2, commands=(cmd_mock,), interval="1")
     with (
         patch("bot.core.control.time") as time,
         patch("bot.core.control.alt_tab") as alt_tab,
@@ -22,7 +22,7 @@ def test_run(params_factory):
 
 def test_run_error(params_factory, caplog):
     cmd_mock = Mock(spec=Command)
-    p = params_factory(commands=[cmd_mock])
+    p = params_factory(commands=(cmd_mock,))
     cmd_mock.execute.side_effect = TypeError
     with patch("bot.core.control.time") as time:
         time.time.side_effect = [1, 1, 99]

--- a/tests/core/test_control.py
+++ b/tests/core/test_control.py
@@ -7,25 +7,25 @@ from bot.models.command import Command
 
 
 def test_run(params_factory):
-    p = params_factory(winNum=2)
-    cmd_mock = Mock()
-    p.commands = [cmd_mock]
+    cmd_mock = Mock(spec=Command)
+    p = params_factory(winNum=2, commands=[cmd_mock], interval="1")
     with (
-        patch("bot.core.control.time.sleep") as sleep,
+        patch("bot.core.control.time") as time,
         patch("bot.core.control.alt_tab") as alt_tab,
     ):
+        time.time.side_effect = [1, 1, 99]
         run(p)
-        assert sleep.call_args_list[0] == call(5)
+        time.sleep.assert_has_calls([call(5), call(1)])
         cmd_mock.execute.assert_called()
         alt_tab.execute.assert_called()
 
 
 def test_run_error(params_factory, caplog):
-    p = params_factory()
     cmd_mock = Mock(spec=Command)
+    p = params_factory(commands=[cmd_mock])
     cmd_mock.execute.side_effect = TypeError
-    p.commands = [cmd_mock]
-    with patch("bot.core.control.time.sleep"):
+    with patch("bot.core.control.time") as time:
+        time.time.side_effect = [1, 1, 99]
         run(p)
     assert caplog.record_tuples[2] == (
         APP_NAME,

--- a/tests/models/test_models.py
+++ b/tests/models/test_models.py
@@ -37,7 +37,7 @@ def test_directional(directional_key_factory):
 def test_params(stroke_factory):
     model = Params(interval="1-5")
     assert model.interval_range == [1, 2, 3, 4, 5]
-    model = Params(limit=5, commands=[stroke_factory()], winNum=1, interval="1")
+    model = Params(limit=5, commands=(stroke_factory(),), winNum=1, interval="1")
     assert model.interval_range == [1]
     assert repr(model) == "winNum 1\nlimit 5\ninterval 1\n\nShift+5 200\n\n"
 

--- a/tests/models/test_models.py
+++ b/tests/models/test_models.py
@@ -35,9 +35,9 @@ def test_directional(directional_key_factory):
 
 
 def test_params(stroke_factory):
-    model = Params(limit=5, commands=[stroke_factory()], winNum=1, interval="1-5")
+    model = Params(interval="1-5")
     assert model.interval_range == [1, 2, 3, 4, 5]
-    model.interval = "1"
+    model = Params(limit=5, commands=[stroke_factory()], winNum=1, interval="1")
     assert model.interval_range == [1]
     assert repr(model) == "winNum 1\nlimit 5\ninterval 1\n\nShift+5 200\n\n"
 

--- a/tests/utils/test_config.py
+++ b/tests/utils/test_config.py
@@ -56,7 +56,7 @@ def test_save_config(params_factory):
             data = f.read()
         assert data == (
             """winNum 1
-limit 0.01
+limit 1
 interval 1-2
 
 Shift+5 200


### PR DESCRIPTION
## Summary by Sourcery

Freeze various model dataclasses for immutability and update related defaults and tests to accommodate the changes

Enhancements:
- Mark BaseKey, Keystroke, DirectionalKeystroke, MouseClick, Params, and Timer dataclasses as frozen
- Change Params default limit from float to integer and refactor params_factory to accept an explicit commands list with a sensible default composition

Tests:
- Adapt factories and model tests to the new Params signature and default behaviors
- Refactor core control tests to mock the entire time module instead of only time.sleep and adjust sleep call assertions
- Update configuration save tests to expect the new integer limit value