### PR TITLE
Fix CI: ensure setuptools available for pyinstaller

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -22,7 +22,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
+          python -m pip install --upgrade pip setuptools
           pip install .
 
       - name: Generate the python ui file


### PR DESCRIPTION
## Summary

- `altgraph==0.17.4` (dependency of pyinstaller) imports `pkg_resources` at startup, which requires `setuptools` — not pre-installed on the Windows GitHub Actions runner with Python 3.12
- Previous fix had a typo (`setuptool` instead of `setuptools`) and was also dropped during the PR merge
- Fix: upgrade `pip` and `setuptools` in the same command before `pip install .`

## Test plan

- [ ] CI build job passes on the next tag push

## Summary by Sourcery

CI:
- Update GitHub Actions build workflow to upgrade both pip and setuptools before running pip install .